### PR TITLE
fix background

### DIFF
--- a/Elegant/Main.qml
+++ b/Elegant/Main.qml
@@ -80,7 +80,7 @@ Rectangle {
         Image {
             id: mainFrameBackground
             anchors.fill: parent
-            source: "background.jpg"
+            source: config.background
         }
 
         FastBlur {


### PR DESCRIPTION
Right now, the background provided by the config is ignored.
The included `background.jpg` is always used.

This patch fixes that.